### PR TITLE
ci: adjust release workflow to use trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Prerelease versions (e.g. v1.0.0-alpha.1) require an explicit dist-tag (not semver-range-like).
+          # Tag checkouts are detached HEAD; Lerna needs a branch.
+          git checkout -B "release-${GITHUB_REF_NAME}" HEAD
+          # prerelease versions require an explicit dist-tag (e.g. 1.0.0-alpha.1).
           if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
-            yarn run publish -- from-git --yes --dist-tag next
+            yarn exec lerna publish from-package --yes --dist-tag next --no-private
           else
-            yarn run publish -- from-git --yes
+            yarn exec lerna publish from-package --yes --no-private
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -21,8 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '24'
           package-manager-cache: false
 
       - name: Install dependencies
@@ -41,12 +43,19 @@ jobs:
         run: yarn quality:test
 
   publish:
+    # Trusted Publishing (OIDC): configure on npmjs.com (as grafanabot) for these packages,
+    # pointing at this repo and the same environment name. Do not use NPM_TOKEN here.
+    # Repo admins: Settings → Environments → create "npm-publish" (or rename below),
+    # restrict to protected branches / tags (e.g. v*) as in internal Grafana runbooks.
+    environment: npm-publish
+
+    needs: [test]
+
+    runs-on: ubuntu-latest
+
     permissions:
       contents: read
       id-token: write
-
-    runs-on: ubuntu-latest
-    needs: [test]
 
     env:
       NPM_CONFIG_ACCESS: public
@@ -61,8 +70,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
-          node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
+          # Node 24.x+ aligns with npm versions suitable for Trusted Publishing; still upgrade npm below.
+          node-version: '24'
           package-manager-cache: false
 
       - name: Install dependencies
@@ -71,8 +80,16 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Install npm latest version #needed for Trusted Publishing
-        run: npm install -g npm@latest
+      - name: Install npm for Trusted Publishing
+        run: npm install -g npm@^11.5.1
 
-      - name: Publish package to NPM
-        run: npm run publish -- from-git --yes
+      - name: Publish packages to npm
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Prerelease versions (e.g. v1.0.0-alpha.1) require an explicit dist-tag (not semver-range-like).
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            yarn run publish -- from-git --yes --dist-tag next
+          else
+            yarn run publish -- from-git --yes
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,11 +357,11 @@ Managed via Lerna:
 # Version packages (prompts for version bump)
 lerna version
 
-# Publish to npm
-lerna publish
+# Publish to npm (root script — do not name it "publish" or npm lifecycles recurse)
+yarn run publish:packages
 
-# Publish from specific packages
-lerna publish from-package
+# Publish versions already in package.json (CI / no bump prompt)
+yarn exec lerna publish from-package --yes --no-private
 ```
 
 **Pre-publish checklist:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This is the Grafana Faro React Native SDK - a monorepo containing packages for r
 - `@grafana/faro-react-native` - Core SDK with instrumentations, metas, and transports
 - `@grafana/faro-react-native-tracing` - OpenTelemetry distributed tracing integration
 - `@grafana/faro-test-utils` - Internal test utilities (not published)
-- `demo/` - Full-featured demo application
+- `demo/` - Full-featured demo application (not published)
 
 **Critical Dependencies:**
 
@@ -54,6 +54,8 @@ yarn quality:circular-deps
 
 ### Demo App Commands
 
+Commands to run from root folder:
+
 ```bash
 # Start Metro bundler
 yarn start:demo
@@ -64,9 +66,6 @@ yarn ios
 # Run on Android (from root)
 yarn android
 
-# Run from demo directory
-cd demo
-yarn ios        # or yarn android
 ```
 
 ### iOS Native Module Setup
@@ -354,14 +353,8 @@ Husky + lint-staged runs automatically:
 Managed via Lerna:
 
 ```bash
-# Version packages (prompts for version bump)
-lerna version
-
-# Publish to npm (root script — do not name it "publish" or npm lifecycles recurse)
-yarn run publish:packages
-
-# Publish versions already in package.json (CI / no bump prompt)
-yarn exec lerna publish from-package --yes --no-private
+# Version packages (prompts for version bump, commit, tags). Push to GitHub to trigger the release workflow.
+yarn bump:version
 ```
 
 **Pre-publish checklist:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ participating, you are expected to uphold this code.
 
 - Node.js (LTS version recommended)
 - Yarn 4.12.0 (included via Yarn Berry)
-- For iOS development: macOS with Xcode installed
+- For iOS development: macOS and iOS with Xcode installed
 - For Android development: Android Studio and SDK installed
 
 ### Initial Setup
@@ -253,7 +253,7 @@ Releases are managed by project maintainers using Lerna:
 1. Version bumping:
 
    ```bash
-   yarn exec lerna version
+   yarn bump:version
    ```
 
 2. Lerna will:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,7 +253,7 @@ Releases are managed by project maintainers using Lerna:
 1. Version bumping:
 
    ```bash
-   yarn publish
+   yarn exec lerna version
    ```
 
 2. Lerna will:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "watch": "lerna run --parallel watch",
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
-    "prepublish": "yarn build",
+    "prepublishOnly": "yarn build",
     "clean": "run-s 'clean:*'",
     "clean:packages": "lerna run --parallel clean",
     "clean:root": "rimraf .cache yarn-error.log",
@@ -42,7 +42,7 @@
     "quality:lint:root:markdown": "markdownlint README.md CHANGELOG.md CONTRIBUTING.md",
     "quality:lint:root:prettier": "prettier --cache --cache-location=.cache/prettier/root -c \"./**/*.{js,jsx,ts,tsx,css,scss,md,yaml,yml,json}\" \"!./{demo,packages}/**\"",
     "quality:circular-deps": "lerna run --parallel quality:circular-deps",
-    "publish": "lerna publish",
+    "publish:packages": "lerna publish",
     "git-hooks": "run-s git-hooks:*",
     "git-hooks:pre-commit": "lint-staged"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "quality:lint:root:markdown": "markdownlint README.md CHANGELOG.md CONTRIBUTING.md",
     "quality:lint:root:prettier": "prettier --cache --cache-location=.cache/prettier/root -c \"./**/*.{js,jsx,ts,tsx,css,scss,md,yaml,yml,json}\" \"!./{demo,packages}/**\"",
     "quality:circular-deps": "lerna run --parallel quality:circular-deps",
-    "publish:packages": "lerna publish",
+    "bump:version": "yarn exec lerna version",
     "git-hooks": "run-s git-hooks:*",
     "git-hooks:pre-commit": "lint-staged"
   },


### PR DESCRIPTION
adjust release workflow to use trusted publishing based on what is defined [here](https://docs.google.com/document/d/1DmypU17btKJ6PkRacwBeI7HoM5nIGoc_ovKTuejaDC8/edit?usp=sharing)