### PR TITLE
chore: fix broken link in readme and clade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,7 @@ This SDK aims for feature parity with:
 
 When implementing new features, check:
 
-- `packages/react-native/FEATURE_PARITY.md` - Detailed comparison with Web SDK
+- `docs/mobile-rum/feature-parity-matrix.md` - Detailed feature comparison between React Native and Flutter SDKs
 - Faro Flutter SDK: If `faro-flutter-sdk` is in the workspace, go to `faro-flutter-sdk/lib/` and inspect for implementation details and patterns. Only search the web if the repo is not in the workspace.
 
 ## Performance Monitoring

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Each package builds to multiple formats:
 
 - [Core SDK Documentation](./packages/react-native/README.md)
 - [Tracing Documentation](./packages/react-native-tracing/README.md)
-- [Feature Parity Matrix](./packages/react-native/FEATURE_PARITY.md)
+- [Feature Parity Matrix](./docs/mobile-rum/feature-parity-matrix.md)
 - [Contributing Guide](./CONTRIBUTING.md)
 - [Changelog](./CHANGELOG.md)
 


### PR DESCRIPTION
## Summary
- Fix broken Feature Parity Matrix link in `README.md` — pointed to nonexistent `packages/react-native/FEATURE_PARITY.md`, now points to `docs/mobile-rum/feature-parity-matrix.md`
- Fix same dead reference in `CLAUDE.md`

## Test plan
- [ ] Verify links resolve correctly on GitHub