### PR TITLE
fix: update addressable gem to 2.9.0 (security)

### DIFF
--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.9)
+    CFPropertyList (3.0.8)
     activesupport (6.1.7.10)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
@@ -105,7 +105,7 @@ DEPENDENCIES
   xcodeproj (< 1.26.0)
 
 RUBY VERSION
-   ruby 2.6.10p210
+  ruby 2.6.10p210
 
 BUNDLED WITH
-   1.17.2
+  4.0.3

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.8)
+    CFPropertyList (3.0.9)
     activesupport (6.1.7.10)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -105,7 +105,7 @@ DEPENDENCIES
   xcodeproj (< 1.26.0)
 
 RUBY VERSION
-  ruby 2.6.10p210
+   ruby 2.6.10p210
 
 BUNDLED WITH
-  4.0.3
+   1.17.2


### PR DESCRIPTION
## Summary
- Updates `addressable` gem from 2.8.8 to 2.9.0 in `demo/Gemfile.lock` to resolve Dependabot security alert
- The `~> 2.8` constraint from cocoapods allows versions `>= 2.8.0, < 3.0.0`, so 2.9.0 is fully compatible

## Test plan
- [ ] Verify `cd demo/ios && pod install` still works
- [ ] Verify iOS demo app builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency lockfile-only change; main risk is unintended gem compatibility issues during `pod install`/iOS demo builds.
> 
> **Overview**
> Updates the `demo` Ruby dependency lockfile to bump `addressable` from `2.8.8` to `2.9.0` (security fix), with no other dependency or code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75eb7079248d7a8fe78ade0a63c30d2804745ec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->