### PR TITLE
fix: avoid bundling faro-core web code in React Native

### DIFF
--- a/packages/react-native/jest.config.js
+++ b/packages/react-native/jest.config.js
@@ -19,6 +19,8 @@ module.exports = {
   ],
   moduleNameMapper: {
     '^@grafana/faro-core/testUtils$': '<rootDir>/node_modules/@grafana/faro-core/dist/esm/testUtils/index.js',
+    '^@grafana/faro-react-native-tracing$':
+      '<rootDir>/packages/react-native/src/testUtils/mockFaroReactNativeTracing.ts',
     ...jestBaseConfig.moduleNameMapper,
   },
   setupFiles: ['<rootDir>/packages/react-native/src/testUtils/setupTests.ts'],

--- a/packages/react-native/src/config/getRNInstrumentations.test.ts
+++ b/packages/react-native/src/config/getRNInstrumentations.test.ts
@@ -1,16 +1,3 @@
-/** Keeps tests working without a workspace devDependency (avoids npm/Lerna cycle: tracing → react-native → tracing). */
-jest.mock('@grafana/faro-react-native-tracing', () => {
-  const { BaseInstrumentation, VERSION } = require('@grafana/faro-core');
-
-  class TracingInstrumentation extends BaseInstrumentation {
-    readonly name = '@grafana/faro-react-native-tracing';
-    readonly version = VERSION;
-    initialize(): void {}
-  }
-
-  return { TracingInstrumentation };
-});
-
 import { Platform } from 'react-native';
 
 import { TracingInstrumentation } from '@grafana/faro-react-native-tracing';

--- a/packages/react-native/src/config/getRNInstrumentations.ts
+++ b/packages/react-native/src/config/getRNInstrumentations.ts
@@ -114,13 +114,15 @@ export function getRNInstrumentations(config: Partial<ReactNativeConfig> = {}): 
     }
   }
 
-  // Performance vitals (CPU/memory)
-  const perfInstrumentation = new PerformanceInstrumentation({
-    memoryUsageVitals,
-    cpuUsageVitals,
-    fetchVitalsInterval,
-  });
-  instrumentations.push(perfInstrumentation);
+  // Performance vitals (CPU/memory) - only add if at least one metric is enabled
+  if (cpuUsageVitals || memoryUsageVitals) {
+    const perfInstrumentation = new PerformanceInstrumentation({
+      memoryUsageVitals,
+      cpuUsageVitals,
+      fetchVitalsInterval,
+    });
+    instrumentations.push(perfInstrumentation);
+  }
 
   // Startup tracking - always enabled
   instrumentations.push(new StartupInstrumentation());

--- a/packages/react-native/src/config/makeRNConfig.ts
+++ b/packages/react-native/src/config/makeRNConfig.ts
@@ -1,9 +1,9 @@
 import { defaultGlobalObjectKey, defaultUnpatchedConsole } from '@grafana/faro-core';
 import type { Config } from '@grafana/faro-core';
 
-import { InternalLoggerLevel, LogLevel } from '../internalLogger';
 import { getStackFramesFromError } from '../instrumentations/errors/stackTraceParser';
 import { defaultSessionTrackingConfig } from '../instrumentations/session/sessionManager/sessionConstants';
+import { InternalLoggerLevel, LogLevel } from '../internalLogger';
 import { getPageMeta } from '../metas/page';
 import { getScreenMeta } from '../metas/screen';
 import { getSdkMeta } from '../metas/sdk';

--- a/packages/react-native/src/config/makeRNConfig.ts
+++ b/packages/react-native/src/config/makeRNConfig.ts
@@ -1,6 +1,7 @@
-import { defaultGlobalObjectKey, defaultUnpatchedConsole, InternalLoggerLevel, LogLevel } from '@grafana/faro-core';
+import { defaultGlobalObjectKey, defaultUnpatchedConsole } from '@grafana/faro-core';
 import type { Config } from '@grafana/faro-core';
 
+import { InternalLoggerLevel, LogLevel } from '../internalLogger';
 import { getStackFramesFromError } from '../instrumentations/errors/stackTraceParser';
 import { defaultSessionTrackingConfig } from '../instrumentations/session/sessionManager/sessionConstants';
 import { getPageMeta } from '../metas/page';

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -110,5 +110,5 @@ export type {
   PushMeasurementOptions,
 } from '@grafana/faro-core';
 
-// Export LogLevel enum (not just the type)
-export { LogLevel } from '@grafana/faro-core';
+// Export LogLevel and InternalLoggerLevel from our local copy (avoid bundling faro-core's web code)
+export { LogLevel, InternalLoggerLevel, allLogLevels, defaultLogLevel } from './internalLogger';

--- a/packages/react-native/src/internalLogger/index.ts
+++ b/packages/react-native/src/internalLogger/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal logger levels - copied from @grafana/faro-core to avoid bundling web code
+ * Keep in sync with @grafana/faro-core's InternalLoggerLevel
+ */
+export enum InternalLoggerLevel {
+  OFF = 0,
+  ERROR = 1,
+  WARN = 2,
+  INFO = 3,
+  VERBOSE = 4,
+}
+
+/**
+ * Log levels for console/logging - copied from @grafana/faro-core to avoid bundling web code
+ * Keep in sync with @grafana/faro-core's LogLevel
+ */
+export enum LogLevel {
+  TRACE = 'trace',
+  DEBUG = 'debug',
+  INFO = 'info',
+  LOG = 'log',
+  WARN = 'warn',
+  ERROR = 'error',
+}
+
+export const defaultLogLevel = LogLevel.LOG;
+export const allLogLevels: ReadonlyArray<Readonly<LogLevel>> = [
+  LogLevel.TRACE,
+  LogLevel.DEBUG,
+  LogLevel.INFO,
+  LogLevel.LOG,
+  LogLevel.WARN,
+  LogLevel.ERROR,
+] as const;

--- a/packages/react-native/src/testUtils/mockFaroReactNativeTracing.ts
+++ b/packages/react-native/src/testUtils/mockFaroReactNativeTracing.ts
@@ -1,0 +1,12 @@
+/**
+ * Jest stub for optional peer `@grafana/faro-react-native-tracing`.
+ * Mapped via moduleNameMapper so tests run without installing the tracing workspace package.
+ */
+import { BaseInstrumentation, VERSION } from '@grafana/faro-core';
+
+export class TracingInstrumentation extends BaseInstrumentation {
+  readonly name = '@grafana/faro-react-native-tracing';
+  readonly version = VERSION;
+
+  initialize(): void {}
+}


### PR DESCRIPTION
**Problem**
The React Native SDK was importing InternalLoggerLevel and LogLevel enums directly from `@grafana/faro-core`, which is a web-based package. When Metro bundler tried to bundle the app, it would include faro-core's web-specific code that contains browser APIs like `window.setInterval`, causing the app to crash with:

```
Error: ENOENT: window is not defined
TypeError: Cannot read property 'VERBOSE' of undefined
```

**Solution**
Created local copies of **InternalLoggerLevel** and **LogLevel** enums in a new `src/internalLogger/index.ts` module to avoid importing runtime code from the web SDK. Updated all internal imports to use the local versions instead.

Type-only imports from faro-core remain unchanged as they don't cause bundling issues (TypeScript strips them at compile time).

Also, add performance instrumentation if any of the flag for cpu or memory are enabled.
