### PR TITLE
docs: improve discoverability of log levels in pushLog API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,21 @@ Husky + lint-staged runs automatically:
 
 **To skip (emergency only):** `git commit --no-verify`
 
+### Pre-PR Checklist
+
+Run these checks locally before opening a pull request to avoid CI failures:
+
+```bash
+# Lint and format all packages (catches Prettier + ESLint issues)
+yarn quality:lint
+
+# Run the full test suite
+yarn quality:test
+
+# Ensure packages compile cleanly
+yarn build
+```
+
 ### Creating Commits
 
 **NEVER include Co-Authored-By: Claude Sonnet 4.5** in commits unless explicitly requested by the user. This was a temporary requirement during migration.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm install @grafana/faro-react-native-tracing
 ### Basic Usage
 
 ```typescript
-import { initializeFaro } from '@grafana/faro-react-native';
+import { initializeFaro, LogLevel } from '@grafana/faro-react-native';
 
 // Initialize Faro
 const faro = initializeFaro({
@@ -62,8 +62,9 @@ const faro = initializeFaro({
   },
 });
 
-// Use it
-faro.api.pushLog(['Application started']);
+// Send logs with different severity levels
+faro.api.pushLog(['Application started']); // defaults to LogLevel.LOG
+faro.api.pushLog(['User signed in'], { level: LogLevel.INFO });
 ```
 
 For detailed usage instructions, see the [core package README](./packages/react-native/README.md).

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -288,14 +288,14 @@ faro.api.pushLog(['Entering auth flow'], { level: LogLevel.TRACE });
 
 **Available log levels** (from `LogLevel` enum):
 
-| Level              | Description                                      |
-| ------------------ | ------------------------------------------------ |
-| `LogLevel.TRACE`   | Fine-grained diagnostic information               |
-| `LogLevel.DEBUG`   | Detailed information useful during development     |
-| `LogLevel.INFO`    | General informational messages                     |
-| `LogLevel.LOG`     | Standard log messages (default when omitted)       |
-| `LogLevel.WARN`    | Potentially harmful situations                     |
-| `LogLevel.ERROR`   | Error events that might still allow the app to run |
+| Level            | Description                                        |
+| ---------------- | -------------------------------------------------- |
+| `LogLevel.TRACE` | Fine-grained diagnostic information                |
+| `LogLevel.DEBUG` | Detailed information useful during development     |
+| `LogLevel.INFO`  | General informational messages                     |
+| `LogLevel.LOG`   | Standard log messages (default when omitted)       |
+| `LogLevel.WARN`  | Potentially harmful situations                     |
+| `LogLevel.ERROR` | Error events that might still allow the app to run |
 
 You can also attach additional context to log messages:
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -268,6 +268,47 @@ faro.api.pushEvent('purchase_completed', {
 });
 ```
 
+### Logging
+
+Send log messages with different severity levels using the `LogLevel` enum:
+
+```tsx
+import { faro, LogLevel } from '@grafana/faro-react-native';
+
+// Default level (LogLevel.LOG) when no level is specified
+faro.api.pushLog(['Application started']);
+
+// Explicit log levels
+faro.api.pushLog(['User signed in'], { level: LogLevel.INFO });
+faro.api.pushLog(['Cache hit ratio: 0.95'], { level: LogLevel.DEBUG });
+faro.api.pushLog(['Retrying request, attempt 3'], { level: LogLevel.WARN });
+faro.api.pushLog(['Payment processing failed'], { level: LogLevel.ERROR });
+faro.api.pushLog(['Entering auth flow'], { level: LogLevel.TRACE });
+```
+
+**Available log levels** (from `LogLevel` enum):
+
+| Level              | Description                                      |
+| ------------------ | ------------------------------------------------ |
+| `LogLevel.TRACE`   | Fine-grained diagnostic information               |
+| `LogLevel.DEBUG`   | Detailed information useful during development     |
+| `LogLevel.INFO`    | General informational messages                     |
+| `LogLevel.LOG`     | Standard log messages (default when omitted)       |
+| `LogLevel.WARN`    | Potentially harmful situations                     |
+| `LogLevel.ERROR`   | Error events that might still allow the app to run |
+
+You can also attach additional context to log messages:
+
+```tsx
+faro.api.pushLog(['Order placed'], {
+  level: LogLevel.INFO,
+  context: {
+    orderId: 'order-456',
+    userId: 'user-123',
+  },
+});
+```
+
 ### Performance Measurements
 
 Track performance metrics:
@@ -1147,7 +1188,7 @@ See the [demo](../../demo) directory for a complete example application.
 
 - `initializeFaro(config: ReactNativeConfig): void` - Initialize the Faro SDK
 - `faro.api.pushEvent(name: string, attributes?: Record<string, string>)` - Track custom events
-- `faro.api.pushLog(message: string, options?: PushLogOptions)` - Send log messages
+- `faro.api.pushLog(message: string[], options?: PushLogOptions)` - Send log messages. Use `options.level` with the `LogLevel` enum (`TRACE`, `DEBUG`, `INFO`, `LOG`, `WARN`, `ERROR`) to set severity. Defaults to `LogLevel.LOG`.
 - `faro.api.pushError(error: Error, options?: PushErrorOptions)` - Report errors
 - `faro.api.pushMeasurement(measurement: Measurement)` - Track performance
 - `faro.api.setUser(user: User)` - Identify users


### PR DESCRIPTION
## Summary
- Add a "Logging" section to the package README with examples of all `LogLevel` values and context usage
- Update the `pushLog` API Reference to document the `level` option and fix the parameter type (`string` → `string[]`)
- Show `LogLevel` import and usage in the root README quick start example
- Add `AGENTS.md` as a symlink to `CLAUDE.md` for Codex users

Closes #22

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm `AGENTS.md` symlink resolves to `CLAUDE.md` content

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; no runtime code or API behavior is modified, but docs now assert `pushLog` takes `string[]` and supports `options.level`, so mismatches with actual typings/behavior would confuse users.
> 
> **Overview**
> **Improves discoverability of log severity for `faro.api.pushLog`.** The root `README.md` quick start now imports `LogLevel` and demonstrates sending logs with explicit severity.
> 
> The package `packages/react-native/README.md` adds a dedicated *Logging* section with examples for all `LogLevel` values, optional `context`, and updates the API reference to document `options.level`, its default (`LogLevel.LOG`), and the `message` parameter as `string[]`.
> 
> Separately, `CLAUDE.md` adds a pre-PR local checklist (lint/test/build), and `AGENTS.md` is added as a symlink-style pointer to `CLAUDE.md` for tooling compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b95ce7f69bcc2881c76719935714d711cb583c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->