### PR TITLE
fix: improve type safety and fix MMKV API usage

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -80,7 +80,7 @@
     "@types/node": "24.10.1",
     "@types/react": "^19.1.1",
     "@types/react-native": "^0.73.0",
-    "react-native-mmkv": "^2.12.2"
+    "react-native-mmkv": "^4.3.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-native/src/config/makeRNConfig.ts
+++ b/packages/react-native/src/config/makeRNConfig.ts
@@ -13,7 +13,7 @@ import { FetchTransport } from '../transports/fetch';
 import { OfflineTransport } from '../transports/offline';
 
 import { getRNInstrumentations } from './getRNInstrumentations';
-import type { ReactNativeConfig, ReactNativeSessionTrackingConfig } from './types';
+import type { ReactNativeConfig, ReactNativeFullConfig } from './types';
 
 const DEFAULT_OFFLINE_CACHE_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
 
@@ -77,7 +77,10 @@ const parseStacktrace: Config['parseStacktrace'] = (err) => ({
  *
  * @param preloadedSessionDeviceAttributes Device/session fields for session meta (passed from async `initializeFaro`).
  */
-export function makeRNConfig(config: ReactNativeConfig, preloadedSessionDeviceAttributes?: SessionAttributes): Config {
+export function makeRNConfig(
+  config: ReactNativeConfig,
+  preloadedSessionDeviceAttributes?: SessionAttributes
+): ReactNativeFullConfig {
   const defaultMetas = [getSdkMeta(), getPageMeta(), getScreenMeta()];
   const customMetas = config.metas ?? [];
   const transports = buildTransports(config);
@@ -104,7 +107,7 @@ export function makeRNConfig(config: ReactNativeConfig, preloadedSessionDeviceAt
     sessionTracking: {
       ...defaultSessionTrackingConfig,
       ...config.sessionTracking,
-    } as ReactNativeSessionTrackingConfig,
+    },
     metas: [...defaultMetas, ...customMetas],
     instrumentations,
     transports,
@@ -114,5 +117,5 @@ export function makeRNConfig(config: ReactNativeConfig, preloadedSessionDeviceAt
     preserveOriginalError: config.preserveOriginalError,
     userActionsInstrumentation: config.userActionsOptions,
     consoleInstrumentation: config.consoleCaptureOptions,
-  } as Config;
+  };
 }

--- a/packages/react-native/src/config/types.ts
+++ b/packages/react-native/src/config/types.ts
@@ -2,6 +2,7 @@ import type { Config } from '@grafana/faro-core';
 
 import type { ANRInstrumentationOptions } from '../instrumentations/anr';
 import type { FrameMonitoringOptions } from '../instrumentations/frameMonitoring';
+import type { SessionAttributes } from '../instrumentations/session/sessionAttributes';
 
 import type { Sampling } from './sampling';
 
@@ -80,3 +81,11 @@ export type ReactNativeConfig = Partial<
   Omit<Config, 'sessionTracking' | 'consoleInstrumentation' | 'userActionsInstrumentation'>
 > &
   ReactNativeConfigOverrides;
+
+/**
+ * Internal full config returned by `makeRNConfig`.
+ * Extends faro-core `Config` with RN-specific fields that instrumentations need at init time.
+ */
+export type ReactNativeFullConfig = Config & {
+  preloadedSessionDeviceAttributes?: SessionAttributes;
+};

--- a/packages/react-native/src/instrumentations/session/index.ts
+++ b/packages/react-native/src/instrumentations/session/index.ts
@@ -1,7 +1,7 @@
 import { BaseInstrumentation, dateNow, EVENT_SESSION_START, genShortID, VERSION } from '@grafana/faro-core';
 import type { Config, Meta, MetaSession, TransportItem } from '@grafana/faro-core';
 
-import type { ReactNativeSessionTrackingConfig } from '../../config/types';
+import type { ReactNativeFullConfig, ReactNativeSessionTrackingConfig } from '../../config/types';
 
 import { minimalSessionDeviceAttributes, type SessionAttributes } from './sessionAttributes';
 import { type FaroUserSession, getSessionManagerByConfig, isSampled } from './sessionManager';
@@ -23,7 +23,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
   private sessionManagerInstance: InstanceType<SessionManager> | undefined;
 
   private getDefaultSessionDeviceAttributes(): SessionAttributes {
-    const cfg = this.config as Config & { preloadedSessionDeviceAttributes?: SessionAttributes };
+    const cfg = this.config as ReactNativeFullConfig;
     if (cfg.preloadedSessionDeviceAttributes != null) {
       return cfg.preloadedSessionDeviceAttributes;
     }
@@ -48,7 +48,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
     initialSession: FaroUserSession;
     emitSessionStartOnInit: boolean;
   } {
-    let storedUserSession: FaroUserSession | null = SessionManagerClass.fetchUserSession() as FaroUserSession | null;
+    let storedUserSession = SessionManagerClass.fetchUserSession();
 
     const sessionsConfigTyped = sessionsConfig as ReactNativeSessionTrackingConfig;
     const maxPersistenceMs = sessionsConfigTyped.maxSessionPersistenceTime ?? MAX_SESSION_PERSISTENCE_TIME;
@@ -73,7 +73,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
 
       initialSession = createUserSessionObject({
         sessionId,
-        isSampled: storedUserSession!.isSampled || false,
+        isSampled: storedUserSession?.isSampled || false,
         started: storedUserSession?.started,
       });
 

--- a/packages/react-native/src/instrumentations/session/sessionManager/MmkvPersistentSessionsManager.ts
+++ b/packages/react-native/src/instrumentations/session/sessionManager/MmkvPersistentSessionsManager.ts
@@ -1,4 +1,5 @@
 import { AppState, type AppStateStatus } from 'react-native';
+import type { MMKV } from 'react-native-mmkv';
 
 import { faro, stringifyExternalJson } from '@grafana/faro-core';
 
@@ -8,9 +9,9 @@ import { STORAGE_KEY, STORAGE_UPDATE_DELAY } from './sessionConstants';
 import { getSessionMetaUpdateHandler, getUserSessionUpdater } from './sessionManagerUtils';
 import type { FaroUserSession } from './types';
 
-function createMmkvInstance(): import('react-native-mmkv').MMKV {
+function createMmkvInstance(): MMKV {
   try {
-    const { MMKV } = require('react-native-mmkv') as typeof import('react-native-mmkv');
+    const { MMKV } = require('react-native-mmkv');
     return new MMKV({ id: 'grafana-faro-react-native-session' });
   } catch {
     throw new Error(
@@ -19,9 +20,9 @@ function createMmkvInstance(): import('react-native-mmkv').MMKV {
   }
 }
 
-let mmkvSingleton: import('react-native-mmkv').MMKV | undefined;
+let mmkvSingleton: MMKV | undefined;
 
-function getMmkv(): import('react-native-mmkv').MMKV {
+function getMmkv(): MMKV {
   if (mmkvSingleton == null) {
     mmkvSingleton = createMmkvInstance();
   }
@@ -53,7 +54,7 @@ export class MmkvPersistentSessionsManager {
 
   static removeUserSession(): void {
     try {
-      getMmkv().delete(STORAGE_KEY);
+      getMmkv().remove(STORAGE_KEY);
     } catch (error) {
       faro.unpatchedConsole?.warn?.('Failed to remove session from MMKV:', error);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,7 +1801,7 @@ __metadata:
     "@types/react": "npm:^19.1.1"
     "@types/react-native": "npm:^0.73.0"
     react-native-device-info: "npm:^11.1.0"
-    react-native-mmkv: "npm:^2.12.2"
+    react-native-mmkv: "npm:^4.3.1"
   peerDependencies:
     "@grafana/faro-react-native-tracing": ">=1.0.0"
     "@react-navigation/native": ">=6.0.0"
@@ -14792,13 +14792,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-mmkv@npm:^2.12.2":
-  version: 2.12.2
-  resolution: "react-native-mmkv@npm:2.12.2"
+"react-native-mmkv@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "react-native-mmkv@npm:4.3.1"
   peerDependencies:
     react: "*"
-    react-native: ">=0.71.0"
-  checksum: 10c0/751b92d60b3526c9bbeac652b840c048b7f1cc4f48179f4e24a45cf14bdcdd08bfc7f3c65fb50c686cae41356ac0d15a21e6da034e2f0907459036dacb67fcbd
+    react-native: "*"
+    react-native-nitro-modules: "*"
+  checksum: 10c0/cfafff8e9837e9244c4544fcf26d8570f66539e97ade7ee9cfd2dc51328b6e793357a29a8336bf6f5a540f894780726ae404fef5059756b157ea3cee2fce6566
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Add ReactNativeFullConfig type to replace ad-hoc casts
- Fix MMKV delete() → remove() to match v4 API
- Remove non-null assertion in favor of optional chaining
- Clean up MMKV type imports (top-level instead of inline)
- Add react-native-mmkv as devDependency for type checking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades `react-native-mmkv` to v4 and changes the persistent session storage API call (`delete`→`remove`), which could affect session persistence behavior at runtime. Type-only refactors are low risk but touch core config/session initialization paths.
> 
> **Overview**
> Updates the React Native SDK’s MMKV integration for `react-native-mmkv@^4.3.1`, including switching session removal to the v4 `remove()` API and adjusting MMKV type imports.
> 
> Tightens type-safety around initialization by introducing `ReactNativeFullConfig` (returned from `makeRNConfig`) to carry `preloadedSessionDeviceAttributes`, and removes a non-null assertion in session restoration logic in favor of optional chaining.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f903d4640a8eaab598852412387cad7caa38b89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->