### PR TITLE
fix(react-native-tracing): register global ContextManager and TextMapPropagator so W3C trace headers are injected on outbound requests

### DIFF
--- a/packages/react-native-tracing/package.json
+++ b/packages/react-native-tracing/package.json
@@ -61,6 +61,7 @@
     "@opentelemetry/otlp-transformer": "^0.208.0",
     "@opentelemetry/resources": "^2.0.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
+    "@opentelemetry/sdk-trace-web": "^2.0.0",
     "@opentelemetry/semantic-conventions": "^1.32.0"
   },
   "peerDependencies": {

--- a/packages/react-native-tracing/src/instrumentation.ts
+++ b/packages/react-native-tracing/src/instrumentation.ts
@@ -1,10 +1,6 @@
 import { context, propagation, trace } from '@opentelemetry/api';
 import type { Attributes } from '@opentelemetry/api';
-import {
-  CompositePropagator,
-  W3CBaggagePropagator,
-  W3CTraceContextPropagator,
-} from '@opentelemetry/core';
+import { CompositePropagator, W3CBaggagePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { defaultResource, resourceFromAttributes } from '@opentelemetry/resources';
 import { BatchSpanProcessor, BasicTracerProvider as ReactNativeTracerProvider } from '@opentelemetry/sdk-trace-base';

--- a/packages/react-native-tracing/src/instrumentation.ts
+++ b/packages/react-native-tracing/src/instrumentation.ts
@@ -1,9 +1,15 @@
-import { context, trace } from '@opentelemetry/api';
+import { context, propagation, trace } from '@opentelemetry/api';
 import type { Attributes } from '@opentelemetry/api';
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { defaultResource, resourceFromAttributes } from '@opentelemetry/resources';
 import { BatchSpanProcessor, BasicTracerProvider as ReactNativeTracerProvider } from '@opentelemetry/sdk-trace-base';
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
+import { StackContextManager } from '@opentelemetry/sdk-trace-web';
 import {
   ATTR_SERVICE_NAME,
   ATTR_SERVICE_VERSION,
@@ -174,6 +180,24 @@ export class TracingInstrumentation extends BaseInstrumentation {
     // Register the provider as the global tracer provider
     // This is CRITICAL for the tracer to generate real trace IDs instead of all zeros
     trace.setGlobalTracerProvider(this.provider);
+
+    // Register a global ContextManager. Without one, OTel falls back to the NoopContextManager,
+    // which always returns ROOT_CONTEXT — so when `@opentelemetry/instrumentation-fetch` does
+    // `context.with(setSpan(active(), createdSpan), () => _addHeaders(...))` the span set on the
+    // wrapped context is invisible inside `_addHeaders` and `propagation.inject` writes nothing.
+    // `StackContextManager` is pure JS (no DOM/Zone deps) and works in React Native.
+    context.setGlobalContextManager(options.contextManager ?? new StackContextManager().enable());
+
+    // Register the global text-map propagator. Without this, OTel falls back to a
+    // NoopTextMapPropagator and `propagation.inject(...)` becomes a no-op, meaning
+    // `traceparent` / `tracestate` (and `baggage`) headers are never written on the
+    // outbound fetch/XHR — so the backend receives no context and starts a new trace.
+    propagation.setGlobalPropagator(
+      options.propagator ??
+        new CompositePropagator({
+          propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+        })
+    );
 
     const { propagateTraceHeaderCorsUrls, fetchInstrumentationOptions, xhrInstrumentationOptions } =
       this.options.instrumentationOptions ?? {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,6 +1784,7 @@ __metadata:
     "@opentelemetry/otlp-transformer": "npm:^0.208.0"
     "@opentelemetry/resources": "npm:^2.0.0"
     "@opentelemetry/sdk-trace-base": "npm:^2.0.0"
+    "@opentelemetry/sdk-trace-web": "npm:^2.0.0"
     "@opentelemetry/semantic-conventions": "npm:^1.32.0"
     "@types/node": "npm:24.10.1"
     "@types/react-native": "npm:^0.73.0"
@@ -3548,6 +3549,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/core@npm:2.7.0":
+  version: 2.7.0
+  resolution: "@opentelemetry/core@npm:2.7.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/4e5efc054f42981f7a8bf22705c04d5677a91e0214da08028abcb06d7e4dd19833ddcc61bdd363911832c111f3ffe914745cfd9e6b4c5cb535ee84ea86a7f0fc
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-fetch@npm:^0.208.0":
   version: 0.208.0
   resolution: "@opentelemetry/instrumentation-fetch@npm:0.208.0"
@@ -3659,6 +3671,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/resources@npm:2.7.0":
+  version: 2.7.0
+  resolution: "@opentelemetry/resources@npm:2.7.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.7.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/44b4df76b9429397db9a9b4b223448ae242a7014949693128de604d871cb4c55e6a612dd9a2cbf5069c2441acafcb990474e85445d463de260b223b7bc3f8143
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-logs@npm:0.208.0":
   version: 0.208.0
   resolution: "@opentelemetry/sdk-logs@npm:0.208.0"
@@ -3736,6 +3760,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-trace-base@npm:2.7.0":
+  version: 2.7.0
+  resolution: "@opentelemetry/sdk-trace-base@npm:2.7.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.7.0"
+    "@opentelemetry/resources": "npm:2.7.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/4f743f6cf51343ec5382d30ddbc4f9c9bb24a04212ca7749b42b6702114eb036960805c3f9284e40d3ce069d9674d06ea662907ff5ef0beb47e41a5654194993
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-trace-base@npm:^2.0.0":
   version: 2.6.1
   resolution: "@opentelemetry/sdk-trace-base@npm:2.6.1"
@@ -3758,6 +3795,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   checksum: 10c0/002296bb929d4992575415ea93c2a68411cd5018c6e7fa27b7cd48e78741b7eddfb87eb0903e7ca42740acb04ac4e8508d00f7651bdc63b433055af955201d31
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace-web@npm:^2.0.0":
+  version: 2.7.0
+  resolution: "@opentelemetry/sdk-trace-web@npm:2.7.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.7.0"
+    "@opentelemetry/sdk-trace-base": "npm:2.7.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/241b647fa9897b142ca56e748ac40a186a2e1879f1fdbb132edc79b2384fdd42d2953b5f99c9203721dfc8a40470b7598087fd57bae38b701fddee030d13f7d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Summary**

Distributed traces between a React Native app instrumented with `@grafana/faro-react-native-tracing` and any backend were not joining: each side produced its own root trace because the traceparent (and tracestate/baggage) headers were never written on outbound fetch/XHR requests. This PR fixes that by completing the OTel registration inside `TracingInstrumentation.initialize()`.

**What was wrong**
TracingInstrumentation.initialize() only called:

- `trace.setGlobalTracerProvider(this.provider)`
…and left the OTel global API with its defaults for the other two pieces:

- `propagation → NoopTextMapPropagator` (so propagation.inject(...) is a no-op).
- `context → NoopContextManager` (so context.with(setSpan(active(), span), fn) does not make span visible inside fn; context.active() always returns ROOT_CONTEXT).
@opentelemetry/instrumentation-fetch injects headers like this:

```
context.with(trace.setSpan(context.active(), createdSpan), () => {
  plugin._addHeaders(options, url); // calls propagation.inject(context.active(), headers)
  ...
});
```
With the noop context manager, the propagator received an empty context, found no span, and skipped injection — so the backend always saw a fresh trace.

**Result**
Outbound requests now carry valid W3C headers, e.g. traceparent: 00-<traceId>-<spanId>-01. Combined with a backend that trusts incoming trace context (e.g. otelhttp with the TraceContext propagator), the client span and backend spans appear under a single trace in Tempo.

**Backwards compatibility**
- Public API unchanged. The existing propagator and contextManager fields in `TracingInstrumentationOptions` are now actually wired up.
- No changes to span shape, exporter, or sampling.

**Test plan**
Run a React Native app with `TracingInstrumentation` and `propagateTraceHeaderCorsUrls` configured for the backend origin.
Trigger an outbound fetch/XHR; confirm the backend span is a child of the client span (single trace in Tempo).