### PR TITLE
fix(react-native-tracing): reduce React Native tracing noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Register React Native tracing defaults that avoid duplicate fetch/XHR spans,
+  filter Metro symbolication requests, and suppress unsupported resource timing
+  warnings.
+
 ## [1.0.0] - 2026-04-15
 
 - Wait until session device attributes are initialized before initializing Faro

--- a/docs/mobile-rum/index.md
+++ b/docs/mobile-rum/index.md
@@ -597,7 +597,7 @@ Faro.initialize(
 
 ##### **React Native SDK**
 
-The SDK automatically tracks HTTP requests made with both **fetch** and **XMLHttpRequest** (including libraries that use XHR, such as axios). No code changes are required—network calls are intercepted and reported.
+By default, the SDK automatically tracks HTTP requests made with **fetch**. Apps that use **XMLHttpRequest** directly, or libraries that use XHR such as axios, should enable XHR tracing explicitly. React Native implements `fetch` on top of XHR, so enabling both for the same URL can report the same logical request twice.
 
 **What is captured:**
 
@@ -693,14 +693,14 @@ The SDK automatically tracks HTTP requests made with the `http` package and **di
 
 #### Key Differences
 
-| Aspect                    | React Native                             | Flutter                                    |
-| ------------------------- | ---------------------------------------- | ------------------------------------------ |
-| **Event name**            | `faro.tracing.fetch` (Web SDK format)    | `http_request`                             |
-| **Success + failure**     | ✅ Both emit event                       | Success only; failures omit `http_request` |
-| **What is tracked**       | fetch + XMLHttpRequest (including axios) | `http` package + dio                       |
-| **Scope**                 | All JS network calls using fetch or XHR  | All code using `http` or `dio`             |
-| **Distributed tracing**   | Optional (`enableTracing`)               | Always on                                  |
-| **Grafana HTTP insights** | ✅ Compatible                            | Via span-to-event mapping                  |
+| Aspect                    | React Native                          | Flutter                                    |
+| ------------------------- | ------------------------------------- | ------------------------------------------ |
+| **Event name**            | `faro.tracing.fetch` (Web SDK format) | `http_request`                             |
+| **Success + failure**     | ✅ Both emit event                    | Success only; failures omit `http_request` |
+| **What is tracked**       | fetch by default; XHR/axios opt-in    | `http` package + dio                       |
+| **Scope**                 | JS network calls using enabled APIs   | All code using `http` or `dio`             |
+| **Distributed tracing**   | Optional (`enableTracing`)            | Always on                                  |
+| **Grafana HTTP insights** | ✅ Compatible                         | Via span-to-event mapping                  |
 
 ---
 
@@ -1557,7 +1557,7 @@ The React Native SDK correlates both **HTTP errors** and **JavaScript errors** w
 - HTTP requests are tracked as `faro.tracing.fetch` events with `http.status_code` (400–599 or 0 for network errors)
 - When a request occurs during an active user action (Started or Halted), the event includes `action.name` and `action.parentId`
 - Grafana FEO links these events to the parent user action via `action_parent_id`, so the HTTP Errors column shows the count per action
-- **When tracing is enabled** (`enableTracing: true`): The OTEL FetchInstrumentation and XMLHttpRequestInstrumentation create spans. A request hook adds `faro.action.user.name` and `faro.action.user.parentId` to each span when an active user action exists. The FaroTraceExporter converts these spans to `faro.tracing.fetch` / `faro.tracing.xml-http-request` events and injects `payload.action` from the span attributes. The span, trace, and event are all correlated to the same user action. The trace remains available for distributed tracing, and the event feeds the HTTP Errors column in the user action table.
+- **When tracing is enabled** (`enableTracing: true`): The OTEL FetchInstrumentation creates spans for `fetch` by default. XMLHttpRequestInstrumentation can be enabled for XHR/axios apps. A request hook adds `faro.action.user.name` and `faro.action.user.parentId` to each span when an active user action exists. The FaroTraceExporter converts these spans to HTTP events and injects `payload.action` from the span attributes. The span, trace, and event are all correlated to the same user action. The trace remains available for distributed tracing, and the event feeds the HTTP Errors column in the user action table.
 
 **JavaScript errors:**
 

--- a/packages/react-native-tracing/CLAUDE.md
+++ b/packages/react-native-tracing/CLAUDE.md
@@ -9,6 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **Key Features:**
 
 - Automatic HTTP request tracing via `fetch()` instrumentation
+- Optional XHR tracing for axios or direct `XMLHttpRequest` apps
 - Manual span creation using OpenTelemetry API
 - W3C Trace Context propagation for distributed tracing
 - Correlation with Faro sessions, users, and device metadata
@@ -60,7 +61,7 @@ faro.api.pushTraces() - Sends to Faro collector
 
 - Main instrumentation class
 - Registers OpenTelemetry provider
-- Sets up fetch instrumentation
+- Sets up fetch instrumentation by default and optional XHR instrumentation
 - Configures span processors and exporters
 - Exposes OTEL APIs via `faro.otel`
 
@@ -137,7 +138,7 @@ parentSpan.end();
 - `traceparent`: Contains trace ID, span ID, flags
 - `tracestate`: Vendor-specific data
 
-Headers are added to fetch requests if URL matches `propagateTraceHeaderCorsUrls` patterns.
+Headers are added to enabled fetch/XHR requests if URL matches `propagateTraceHeaderCorsUrls` patterns.
 
 **Configuration:**
 
@@ -378,12 +379,11 @@ Edit `getDefaultOTELInstrumentations()`:
 
 ```typescript
 export function getDefaultOTELInstrumentations(options) {
-  return [
-    new FetchInstrumentation(options),
-    new XMLHttpRequestInstrumentation(), // New
-  ];
+  return [new FetchInstrumentation(options)];
 }
 ```
+
+Do not enable fetch and XHR for the same React Native URL patterns without filtering one side. React Native implements `fetch()` on top of XHR, so both instrumentations can report the same logical request twice.
 
 ### Updating OpenTelemetry Dependencies
 

--- a/packages/react-native-tracing/README.md
+++ b/packages/react-native-tracing/README.md
@@ -41,11 +41,63 @@ const faro = initializeFaro({
 
 That's it! HTTP requests via `fetch()` are now automatically traced (and correlated with user actions when user action tracking is enabled) and sent to your Faro collector.
 
+## Fetch vs XHR in React Native
+
+By default, this package traces `fetch()` requests only.
+
+React Native implements `fetch()` on top of `XMLHttpRequest`. If both fetch and XHR instrumentation are enabled for the same URL, one logical `fetch()` request can produce two spans: one from `FetchInstrumentation` and one from the underlying XHR layer. To avoid duplicate HTTP telemetry, XHR tracing is disabled by default.
+
+If your app uses axios or direct `XMLHttpRequest` calls instead of `fetch()`, enable XHR tracing explicitly:
+
+```typescript
+initializeFaro({
+  enableTracing: true,
+  tracingOptions: {
+    instrumentationOptions: {
+      enableXhrInstrumentation: true,
+    },
+  },
+});
+```
+
+If your app uses both `fetch()` and axios/XHR, avoid tracing the same request twice. Either trace one API surface only:
+
+```typescript
+initializeFaro({
+  enableTracing: true,
+  tracingOptions: {
+    instrumentationOptions: {
+      // Useful for axios/direct XHR apps.
+      enableFetchInstrumentation: false,
+      enableXhrInstrumentation: true,
+    },
+  },
+});
+```
+
+Or enable both and use `ignoreUrls` on one instrumentation so URL patterns do not overlap:
+
+```typescript
+initializeFaro({
+  enableTracing: true,
+  tracingOptions: {
+    instrumentationOptions: {
+      enableXhrInstrumentation: true,
+      xhrInstrumentationOptions: {
+        // Example: fetch() handles your API calls, so ignore those URLs in XHR.
+        ignoreUrls: [/\/api\//],
+      },
+    },
+  },
+});
+```
+
 ## Features
 
 ### 🚀 **Automatic Tracing**
 
-- **Fetch Instrumentation**: HTTP requests are automatically traced with no code changes
+- **Fetch Instrumentation**: `fetch()` requests are automatically traced with no code changes
+- **Optional XHR Instrumentation**: Enable for axios or direct `XMLHttpRequest` calls
 - **Session Correlation**: Traces are correlated with Faro sessions for complete user journey tracking
 - **User Action Correlation**: Traces are correlated with Faro user actions (when user action tracking is enabled)
 - **User Context**: User information is automatically added to span attributes
@@ -114,6 +166,10 @@ new TracingInstrumentation({
     // URLs that should receive trace context headers
     propagateTraceHeaderCorsUrls: [/https:\/\/api\.example\.com/, 'https://other-api.com'],
 
+    // Optional: enable XHR tracing for apps that use axios or XHR directly.
+    // Disabled by default because React Native's current fetch implementation is backed by XHR.
+    enableXhrInstrumentation: false,
+
     // Optional: Customize fetch instrumentation
     fetchInstrumentationOptions: {
       // Ignore network performance events (default: true)
@@ -157,10 +213,10 @@ new TracingInstrumentation({
 
 ### Automatic HTTP Tracing
 
-HTTP requests are automatically traced with no code changes:
+`fetch()` requests are automatically traced with no code changes:
 
 ```typescript
-// This fetch call is automatically traced
+// This fetch call is automatically traced by default.
 const response = await fetch('https://api.example.com/users');
 const data = await response.json();
 
@@ -171,6 +227,23 @@ const data = await response.json();
 // - Session ID, user info
 // - Device metadata
 ```
+
+### Axios and Direct XHR Tracing
+
+Axios and direct `XMLHttpRequest` calls require XHR instrumentation:
+
+```typescript
+initializeFaro({
+  enableTracing: true,
+  tracingOptions: {
+    instrumentationOptions: {
+      enableXhrInstrumentation: true,
+    },
+  },
+});
+```
+
+If the same app also uses `fetch()` for the same backend URLs, add `ignoreUrls` to either fetch or XHR instrumentation to avoid duplicate spans.
 
 **Trace includes:**
 
@@ -359,8 +432,8 @@ function performOperation() {
                        │ fetch() / XHR calls
                        ↓
 ┌─────────────────────────────────────────────────────────────┐
-│       FetchInstrumentation + XMLHttpRequestInstrumentation  │
-│  • Intercepts fetch() and XMLHttpRequest calls              │
+│       FetchInstrumentation, optionally XMLHttpRequest        │
+│  • Intercepts fetch() by default                            │
 │  • Creates spans automatically                               │
 │  • Propagates W3C Trace Context headers                      │
 └──────────────────────┬──────────────────────────────────────┘
@@ -408,7 +481,7 @@ function performOperation() {
 
 ### Span Lifecycle
 
-1. **Span Creation**: FetchInstrumentation or XMLHttpRequestInstrumentation creates a span when fetch()/XHR is called; W3C Trace Context headers added to the request (if URL matches `propagateTraceHeaderCorsUrls`)
+1. **Span Creation**: FetchInstrumentation creates a span when fetch() is called; XMLHttpRequestInstrumentation can be enabled for XHR/axios apps. W3C Trace Context headers are added to the request if the URL matches `propagateTraceHeaderCorsUrls`.
 2. **Enrichment**: HttpRequestMonitorSpanProcessor notifies for user action correlation; FaroMetaAttributesSpanProcessor adds session and user to spans (device/service come from resource)
 3. **Batching**: BatchSpanProcessor collects spans (max 30 spans or 1000ms delay)
 4. **Export**: FaroTraceExporter converts spans to OTLP format; also sends Faro events (e.g. `faro.tracing.fetch`) for CLIENT spans
@@ -667,10 +740,10 @@ interface TracingInstrumentationOptions {
   // Custom OTEL propagator (default: W3CTraceContextPropagator)
   propagator?: TextMapPropagator;
 
-  // Custom OTEL context manager (default: ZoneContextManager)
+  // Custom OTEL context manager (default: StackContextManager)
   contextManager?: ContextManager;
 
-  // Custom OTEL instrumentations (replaces default FetchInstrumentation)
+  // Custom OTEL instrumentations (replaces default fetch/XHR instrumentations)
   instrumentations?: Instrumentation[];
 
   // Custom span processor (replaces default BatchSpanProcessor)
@@ -680,6 +753,12 @@ interface TracingInstrumentationOptions {
   instrumentationOptions?: {
     // URLs to propagate trace headers to
     propagateTraceHeaderCorsUrls?: Array<string | RegExp>;
+
+    // Enable fetch instrumentation (default: true)
+    enableFetchInstrumentation?: boolean;
+
+    // Enable XHR instrumentation (default: false)
+    enableXhrInstrumentation?: boolean;
 
     // Fetch instrumentation options
     fetchInstrumentationOptions?: {
@@ -716,6 +795,7 @@ function getDefaultOTELInstrumentations(options?: DefaultInstrumentationsOptions
 Currently returns:
 
 - `FetchInstrumentation` - Automatic HTTP tracing
+- `XMLHttpRequestInstrumentation` - Optional; enabled with `enableXhrInstrumentation: true`
 
 ### faro.otel
 

--- a/packages/react-native-tracing/src/instrumentation.ts
+++ b/packages/react-native-tracing/src/instrumentation.ts
@@ -16,6 +16,7 @@ import { BaseInstrumentation, getInternalFaroFromGlobalObject, VERSION } from '@
 import type { Transport } from '@grafana/faro-core';
 
 import { FaroTraceExporter } from './exporters/faroTraceExporter';
+import { getReactNativeDevServerIgnoreUrls } from './instrumentations/devServerIgnoreUrls';
 import { getDefaultOTELInstrumentations } from './instrumentations/getDefaultOTELInstrumentations';
 import { FaroMetaAttributesSpanProcessor } from './processors/faroMetaAttributesSpanProcessor';
 import { HttpRequestMonitorSpanProcessor } from './processors/httpRequestMonitorSpanProcessor';
@@ -195,8 +196,13 @@ export class TracingInstrumentation extends BaseInstrumentation {
         })
     );
 
-    const { propagateTraceHeaderCorsUrls, fetchInstrumentationOptions, xhrInstrumentationOptions } =
-      this.options.instrumentationOptions ?? {};
+    const {
+      enableFetchInstrumentation,
+      enableXhrInstrumentation,
+      propagateTraceHeaderCorsUrls,
+      fetchInstrumentationOptions,
+      xhrInstrumentationOptions,
+    } = this.options.instrumentationOptions ?? {};
 
     // Get ignore URLs from transports to prevent infinite loops
     const ignoreUrls = this.getIgnoreUrls();
@@ -207,6 +213,8 @@ export class TracingInstrumentation extends BaseInstrumentation {
         options.instrumentations ??
         getDefaultOTELInstrumentations({
           ignoreUrls,
+          enableFetchInstrumentation,
+          enableXhrInstrumentation,
           propagateTraceHeaderCorsUrls,
           fetchInstrumentationOptions,
           xhrInstrumentationOptions,
@@ -246,8 +254,8 @@ export class TracingInstrumentation extends BaseInstrumentation {
       return url;
     });
 
-    // Return both original URLs and regex patterns for maximum coverage
-    return [...transportUrls, ...regexPatterns];
+    // Return dev-server, original transport URLs, and regex patterns for maximum coverage.
+    return [...getReactNativeDevServerIgnoreUrls(), ...transportUrls, ...regexPatterns];
   }
 
   /**

--- a/packages/react-native-tracing/src/instrumentations/devServerIgnoreUrls.test.ts
+++ b/packages/react-native-tracing/src/instrumentations/devServerIgnoreUrls.test.ts
@@ -1,0 +1,23 @@
+import { getReactNativeDevServerIgnoreUrls } from './devServerIgnoreUrls';
+
+describe('getReactNativeDevServerIgnoreUrls', () => {
+  const ignoredUrlPattern = getReactNativeDevServerIgnoreUrls()[0] as RegExp;
+
+  it.each([
+    'http://localhost:8081/symbolicate',
+    'http://localhost:8081/symbolicate?platform=ios',
+    'http://127.0.0.1:8081/symbolicate',
+    'http://[::1]:8081/symbolicate',
+    'http://10.0.2.2:8081/symbolicate',
+  ])('matches React Native dev-server symbolication URL %s', (url) => {
+    expect(ignoredUrlPattern.test(url)).toBe(true);
+  });
+
+  it.each([
+    'https://api.example.com/symbolicate',
+    'https://api.example.com/v1/symbolicate',
+    'https://api.example.com/symbolicate-events',
+  ])('does not match backend symbolication-like URL %s', (url) => {
+    expect(ignoredUrlPattern.test(url)).toBe(false);
+  });
+});

--- a/packages/react-native-tracing/src/instrumentations/devServerIgnoreUrls.ts
+++ b/packages/react-native-tracing/src/instrumentations/devServerIgnoreUrls.ts
@@ -1,0 +1,9 @@
+import type { MatchUrlDefinitions } from '../types';
+
+const REACT_NATIVE_DEV_SERVER_IGNORE_URLS: MatchUrlDefinitions = [
+  /^https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\]|10\.0\.2\.2)(?::\d+)?\/symbolicate(?:[/?#]|$)/,
+];
+
+export function getReactNativeDevServerIgnoreUrls(): MatchUrlDefinitions {
+  return REACT_NATIVE_DEV_SERVER_IGNORE_URLS;
+}

--- a/packages/react-native-tracing/src/instrumentations/getDefaultOTELInstrumentations.test.ts
+++ b/packages/react-native-tracing/src/instrumentations/getDefaultOTELInstrumentations.test.ts
@@ -4,22 +4,48 @@ import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xm
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
 
 describe('getDefaultOTELInstrumentations', () => {
-  it('should return an array with FetchInstrumentation and XMLHttpRequestInstrumentation', () => {
+  it('should return FetchInstrumentation by default', () => {
     const instrumentations = getDefaultOTELInstrumentations();
+
+    expect(instrumentations).toHaveLength(1);
+    expect(instrumentations[0]).toBeInstanceOf(FetchInstrumentation);
+  });
+
+  it('should allow enabling XMLHttpRequestInstrumentation', () => {
+    const instrumentations = getDefaultOTELInstrumentations({
+      enableXhrInstrumentation: true,
+    });
 
     expect(instrumentations).toHaveLength(2);
     expect(instrumentations[0]).toBeInstanceOf(FetchInstrumentation);
     expect(instrumentations[1]).toBeInstanceOf(XMLHttpRequestInstrumentation);
   });
 
+  it('should allow using only XMLHttpRequestInstrumentation', () => {
+    const instrumentations = getDefaultOTELInstrumentations({
+      enableFetchInstrumentation: false,
+      enableXhrInstrumentation: true,
+    });
+
+    expect(instrumentations).toHaveLength(1);
+    expect(instrumentations[0]).toBeInstanceOf(XMLHttpRequestInstrumentation);
+  });
+
   it('should configure ignoreUrls', () => {
     const ignoreUrls = [/test-url/];
     const instrumentations = getDefaultOTELInstrumentations({ ignoreUrls });
 
-    expect(instrumentations).toHaveLength(2);
-    // FetchInstrumentation should have ignoreUrls configured
+    expect(instrumentations).toHaveLength(1);
     expect((instrumentations[0] as any)._config.ignoreUrls).toEqual(ignoreUrls);
-    // XMLHttpRequestInstrumentation should have ignoreUrls configured
+  });
+
+  it('should configure ignoreUrls for XMLHttpRequestInstrumentation', () => {
+    const ignoreUrls = [/test-url/];
+    const instrumentations = getDefaultOTELInstrumentations({
+      enableXhrInstrumentation: true,
+      ignoreUrls,
+    });
+
     expect((instrumentations[1] as any)._config.ignoreUrls).toEqual(ignoreUrls);
   });
 
@@ -56,7 +82,7 @@ describe('getDefaultOTELInstrumentations', () => {
       },
     });
 
-    expect(instrumentations).toHaveLength(2);
+    expect(instrumentations).toHaveLength(1);
     // Custom function should be wrapped by our defaults
     expect((instrumentations[0] as any)._config.applyCustomAttributesOnSpan).toBeDefined();
   });

--- a/packages/react-native-tracing/src/instrumentations/getDefaultOTELInstrumentations.ts
+++ b/packages/react-native-tracing/src/instrumentations/getDefaultOTELInstrumentations.ts
@@ -16,7 +16,7 @@ import {
  *
  * This function creates the default OpenTelemetry instrumentations for React Native:
  * - FetchInstrumentation: Traces fetch() API calls
- * - XMLHttpRequestInstrumentation: Traces XMLHttpRequest and axios (which uses XHR)
+ * - XMLHttpRequestInstrumentation: Optional for apps that use XHR/axios directly
  *
  * IMPORTANT: Infinite loop prevention
  * - ignoreUrls is used to exclude Faro collector URLs
@@ -27,12 +27,29 @@ import {
  * @returns Array of OTEL instrumentations
  */
 export function getDefaultOTELInstrumentations(options: DefaultInstrumentationsOptions = {}): InstrumentationOption[] {
-  const { fetchInstrumentationOptions, xhrInstrumentationOptions, ...sharedOptions } = options;
+  const {
+    enableFetchInstrumentation = true,
+    enableXhrInstrumentation = false,
+    fetchInstrumentationOptions,
+    xhrInstrumentationOptions,
+    ...sharedOptions
+  } = options;
 
-  const fetchOpts = createFetchInstrumentationOptions(fetchInstrumentationOptions, sharedOptions);
-  const xhrOpts = createXhrInstrumentationOptions(xhrInstrumentationOptions, sharedOptions);
+  const instrumentations: InstrumentationOption[] = [];
 
-  return [new FetchInstrumentation(fetchOpts), new XMLHttpRequestInstrumentation(xhrOpts)];
+  if (enableFetchInstrumentation) {
+    instrumentations.push(
+      new FetchInstrumentation(createFetchInstrumentationOptions(fetchInstrumentationOptions, sharedOptions))
+    );
+  }
+
+  if (enableXhrInstrumentation) {
+    instrumentations.push(
+      new XMLHttpRequestInstrumentation(createXhrInstrumentationOptions(xhrInstrumentationOptions, sharedOptions))
+    );
+  }
+
+  return instrumentations;
 }
 
 function createFetchInstrumentationOptions(

--- a/packages/react-native-tracing/src/types.ts
+++ b/packages/react-native-tracing/src/types.ts
@@ -26,6 +26,8 @@ export type MatchUrlDefinitions = Patterns;
 export type DefaultInstrumentationsOptions = {
   ignoreUrls?: MatchUrlDefinitions;
   propagateTraceHeaderCorsUrls?: MatchUrlDefinitions;
+  enableFetchInstrumentation?: boolean;
+  enableXhrInstrumentation?: boolean;
 
   fetchInstrumentationOptions?: {
     applyCustomAttributesOnSpan?: FetchCustomAttributeFunction;

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -47,7 +47,12 @@ initializeFaro({
   fetchVitalsInterval: 30000, // optional, ms
   frameMonitoringOptions: {}, // optional, when refreshRateVitals true
   enableTracing: false, // optional, requires @grafana/faro-react-native-tracing
-  tracingOptions: {}, // optional
+  tracingOptions: {
+    instrumentationOptions: {
+      // Traces fetch() by default. Enable this for axios/direct XHR apps.
+      enableXhrInstrumentation: false,
+    },
+  }, // optional
 
   // Instrumentation options - optional
   consoleCaptureOptions: {},
@@ -85,8 +90,8 @@ initializeFaro({
 - **App State Instrumentation** - Tracks when app goes to background/foreground
 - **Performance Instrumentation** - Monitors CPU usage, memory usage, and app startup time using native OS APIs
 - **Startup Instrumentation** - Automatically tracks app startup duration from process start
-- **HTTP Instrumentation** - Tracks HTTP requests (fetch) and correlates them with user actions
-- **XHR Instrumentation** - Tracks XMLHttpRequest calls (replaced by TracingInstrumentation when `enableTracing` is true)
+- **HTTP Instrumentation** - Tracks `fetch()` requests and correlates them with user actions
+- **XHR Instrumentation** - Tracks `XMLHttpRequest` calls when tracing is disabled; with `enableTracing: true`, enable XHR tracing via `tracingOptions.instrumentationOptions.enableXhrInstrumentation`
 
 **Enabled by default** (opt-out via config):
 

--- a/packages/react-native/src/util/performanceObserverPolyfill.test.ts
+++ b/packages/react-native/src/util/performanceObserverPolyfill.test.ts
@@ -1,0 +1,48 @@
+import { applyPerformanceObserverPolyfill } from './performanceObserverPolyfill';
+
+describe('applyPerformanceObserverPolyfill', () => {
+  const originalPerformance = global.performance;
+  const originalPerformanceObserver = global.PerformanceObserver;
+
+  afterEach(() => {
+    Object.defineProperty(global, 'performance', {
+      configurable: true,
+      value: originalPerformance,
+      writable: true,
+    });
+    Object.defineProperty(global, 'PerformanceObserver', {
+      configurable: true,
+      value: originalPerformanceObserver,
+      writable: true,
+    });
+  });
+
+  it('returns an empty list for unsupported resource timing lookups', () => {
+    const getEntriesByType = jest.fn(() => [{ entryType: 'mark', name: 'test' }]);
+    Object.defineProperty(global, 'performance', {
+      configurable: true,
+      value: { getEntriesByType },
+      writable: true,
+    });
+
+    applyPerformanceObserverPolyfill();
+
+    expect(global.performance.getEntriesByType('resource')).toEqual([]);
+    expect(getEntriesByType).not.toHaveBeenCalledWith('resource');
+  });
+
+  it('delegates non-resource timing lookups to the original implementation', () => {
+    const markEntry = { entryType: 'mark', name: 'test' };
+    const getEntriesByType = jest.fn(() => [markEntry]);
+    Object.defineProperty(global, 'performance', {
+      configurable: true,
+      value: { getEntriesByType },
+      writable: true,
+    });
+
+    applyPerformanceObserverPolyfill();
+
+    expect(global.performance.getEntriesByType('mark')).toEqual([markEntry]);
+    expect(getEntriesByType).toHaveBeenCalledWith('mark');
+  });
+});

--- a/packages/react-native/src/util/performanceObserverPolyfill.ts
+++ b/packages/react-native/src/util/performanceObserverPolyfill.ts
@@ -74,16 +74,20 @@ class NoopPerformanceObserver {
 }
 
 /**
- * Apply polyfill on React Native iOS to prevent bad_variant_access crash.
- * Must run before any code that might use PerformanceObserver.
+ * Apply React Native performance API compatibility patches.
+ *
+ * Resource Timing lookup is patched on all platforms because OTel web
+ * instrumentation can probe it. The PerformanceObserver replacement is
+ * iOS-only to avoid the native bad_variant_access crash.
  */
 export function applyPerformanceObserverPolyfill(): void {
+  const record = globalObj as Record<string, unknown>;
+  patchUnsupportedResourceTimingLookup(record);
+
   if (Platform.OS !== 'ios') {
     return;
   }
 
-  const record = globalObj as Record<string, unknown>;
-  patchUnsupportedResourceTimingLookup(record);
   const existing = record['PerformanceObserver'];
   if (existing && (existing as unknown as { name?: string }).name === 'NoopPerformanceObserver') {
     return; // Already applied

--- a/packages/react-native/src/util/performanceObserverPolyfill.ts
+++ b/packages/react-native/src/util/performanceObserverPolyfill.ts
@@ -21,6 +21,9 @@ const globalObj =
   (typeof window !== 'undefined' && window) ||
   {};
 
+const RESOURCE_ENTRY_TYPE = 'resource';
+const FARO_RESOURCE_TIMING_PATCH = '__faroResourceTimingPatch';
+
 interface PerformanceEntry {
   readonly duration: number;
   readonly entryType: string;
@@ -80,6 +83,7 @@ export function applyPerformanceObserverPolyfill(): void {
   }
 
   const record = globalObj as Record<string, unknown>;
+  patchUnsupportedResourceTimingLookup(record);
   const existing = record['PerformanceObserver'];
   if (existing && (existing as unknown as { name?: string }).name === 'NoopPerformanceObserver') {
     return; // Already applied
@@ -89,5 +93,37 @@ export function applyPerformanceObserverPolyfill(): void {
     record['PerformanceObserver'] = NoopPerformanceObserver;
   } catch {
     // Ignore if global is frozen (e.g. in some test environments)
+  }
+}
+
+function patchUnsupportedResourceTimingLookup(record: Record<string, unknown>): void {
+  const performance = record['performance'] as
+    | {
+        getEntriesByType?: ((entryType: string) => PerformanceEntry[]) & Record<string, boolean>;
+      }
+    | undefined;
+
+  if (!performance?.getEntriesByType || performance.getEntriesByType[FARO_RESOURCE_TIMING_PATCH]) {
+    return;
+  }
+
+  const originalGetEntriesByType = performance.getEntriesByType.bind(performance);
+  const patchedGetEntriesByType = ((entryType: string): PerformanceEntry[] => {
+    if (entryType === RESOURCE_ENTRY_TYPE) {
+      // OTel web fetch instrumentation probes browser Resource Timing APIs.
+      // React Native does not expose resource entries, and calling through emits
+      // "Deprecated API for given entry type." warnings in development.
+      return [];
+    }
+
+    return originalGetEntriesByType(entryType);
+  }) as typeof performance.getEntriesByType;
+
+  patchedGetEntriesByType[FARO_RESOURCE_TIMING_PATCH] = true;
+
+  try {
+    performance.getEntriesByType = patchedGetEntriesByType;
+  } catch {
+    // Ignore if performance is read-only in a test or host environment.
   }
 }


### PR DESCRIPTION
## Summary

- Make React Native tracing use fetch instrumentation by default and XHR instrumentation opt-in to avoid duplicate spans for RN fetch requests.
- Filter Metro dev-server `/symbolicate` requests without ignoring real backend `/symbolicate` endpoints.
- Suppress unsupported React Native resource timing lookups that caused `Deprecated API for given entry type.` warnings.
- Update README, mobile RUM docs, and changelog to document fetch vs XHR behavior clearly.

## Verification

- `yarn build`
- `yarn quality:test`
- `yarn quality:lint`
- `yarn quality:circular-deps`
- Verified locally in the QuickPizza React Native demo with packed SDK tarballs:
  - e2e trace propagation still works
  - duplicate fetch/XHR telemetry is gone
  - `Deprecated API for given entry type.` warning is gone
  - Metro `/symbolicate` requests are no longer traced

Fixes #32
Fixes #33

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default OpenTelemetry instrumentation selection in `@grafana/faro-react-native-tracing` (XHR now opt-in) and expands global performance polyfills, which can alter what HTTP spans/events are produced and which URLs are ignored.
> 
> **Overview**
> **Reduces React Native tracing noise and duplicates** by making OTEL `FetchInstrumentation` the default and gating `XMLHttpRequestInstrumentation` behind new `instrumentationOptions` toggles (`enableFetchInstrumentation`, `enableXhrInstrumentation`). Adds tests and type updates to support the new defaults and configuration.
> 
> **Filters development-only traffic and warnings** by always ignoring Metro dev-server `/symbolicate` requests in tracing, and by patching `performance.getEntriesByType('resource')` to return `[]` to suppress unsupported Resource Timing warnings. Docs/READMEs/changelog are updated to clarify fetch-vs-XHR behavior and recommended configuration to avoid duplicate spans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d11303b706f344f30f36ce8105a858fa31d292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->