### PR TITLE
Add CODEOWNERS pointing to mobile-o11y-engineers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grafana/mobile-o11y-engineers


### PR DESCRIPTION
## Summary

- Add `.github/CODEOWNERS` so `@grafana/mobile-o11y-engineers` is auto-requested for review on PRs. Team already has write access.

_PR description authored by Claude on Domas's behalf._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk; adds a `.github/CODEOWNERS` file to auto-request reviews and does not affect runtime code or behavior.
> 
> **Overview**
> Adds a new `.github/CODEOWNERS` entry assigning all paths (`*`) to `@grafana/mobile-o11y-engineers`, so this team is automatically requested for review on future PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a4690ad810ef1de8781303f84d92b1d2912469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->