### PR TITLE
fix: unblock release-please by breaking workspace dep cycle

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -61,16 +61,12 @@
     "react-native-device-info": "^11.1.0"
   },
   "peerDependencies": {
-    "@grafana/faro-react-native-tracing": ">=1.0.0",
     "@react-navigation/native": ">=6.0.0",
     "react": ">=18.0.0",
     "react-native": ">=0.70.0",
     "react-native-mmkv": ">=2.0.0"
   },
   "peerDependenciesMeta": {
-    "@grafana/faro-react-native-tracing": {
-      "optional": true
-    },
     "@react-navigation/native": {
       "optional": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,14 +1935,11 @@ __metadata:
     react-native-mmkv: "npm:4.3.1"
     react-native-nitro-modules: "npm:0.35.6"
   peerDependencies:
-    "@grafana/faro-react-native-tracing": ">=1.0.0"
     "@react-navigation/native": ">=6.0.0"
     react: ">=18.0.0"
     react-native: ">=0.70.0"
     react-native-mmkv: ">=2.0.0"
   peerDependenciesMeta:
-    "@grafana/faro-react-native-tracing":
-      optional: true
     "@react-navigation/native":
       optional: true
     react-native-mmkv:


### PR DESCRIPTION
## Summary

- Drop the optional peer-dep on `@grafana/faro-react-native-tracing` from [packages/react-native/package.json](packages/react-native/package.json). Combined with tracing's `workspace:^` dep on base, it formed a cycle release-please's `node-workspace` plugin refused to release through ([failing run](https://github.com/grafana/faro-react-native-sdk/actions/runs/26441178356/job/77838582772)).
- No runtime change: `getRNInstrumentations()` already loads tracing via a guarded `require()`, and the `workspace:^` from the tracing side enforces version compatibility.

_PR description authored by Claude on Domas's behalf._