### PR TITLE
fix: enable manual trigger to release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  # Manual retry when a push to main does not enqueue this workflow (rare GitHub delivery miss).
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
enable manual trigger to release please to allow us to test the workflow in case when github don't trigger it