### PR TITLE
chore(ci): pin actions/checkout to v6.0.2 consistently

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -81,7 +81,7 @@ jobs:
           github_app: app-o11y-kwl-ci
 
       - name: Checkout release PR branch
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.release-please.outputs.release_pr_branch }}
           token: ${{ steps.get-github-app-token.outputs.token }}
@@ -144,7 +144,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: main
@@ -192,7 +192,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: main


### PR DESCRIPTION
## Summary

`release-please.yml` was pinning `actions/checkout` to `8e8c483` (an older non-tag commit on the v6 line), while `codeql.yml`, `dependency-review.yml`, and `pull-request.yml` use `de0fac2` (current v6.0.2 / v6 tip). Align all six references to `de0fac2 # v6.0.2` so Renovate can bump the whole repo in one go.

No functional change.

_PR description authored by Claude on Domas's behalf._