### PR TITLE
chore: add scheduled branch cleanup report

### DIFF
--- a/.github/workflows/branch-cleanup-dry-run.yaml
+++ b/.github/workflows/branch-cleanup-dry-run.yaml
@@ -1,0 +1,131 @@
+name: Branch Cleanup Dry Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: GitHub owner or organization to audit
+        required: true
+        default: grafana
+      repo:
+        description: Repository to audit
+        required: true
+        default: faro-react-native-sdk
+      min_merged_age_days:
+        description: Minimum age in days before merged branches are cleanup candidates
+        required: true
+        default: "14"
+      include_automation:
+        description: Include renovate/dependabot/release-please branches as candidates
+        required: true
+        type: boolean
+        default: false
+      create_issue:
+        description: Create a GitHub issue with the report
+        required: true
+        type: boolean
+        default: false
+  schedule:
+    # GitHub cron does not support "every 14 days" directly. This runs weekly,
+    # then the cadence step below only lets the report continue every other week.
+    - cron: "0 14 * * 4"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  audit:
+    name: Audit stale branches
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check 14-day report cadence
+        id: cadence
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REPORT_ANCHOR_DATE: "2026-05-28"
+        run: |
+          if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "run_report=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          today="$(date -u +%F)"
+          today_seconds="$(date -u -d "$today" +%s)"
+          anchor_seconds="$(date -u -d "$REPORT_ANCHOR_DATE" +%s)"
+          days_since_anchor="$(( (today_seconds - anchor_seconds) / 86400 ))"
+
+          if [ "$(( days_since_anchor % 14 ))" -eq 0 ]; then
+            echo "run_report=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_report=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping branch cleanup report. Next report runs on the 14-day cadence." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Checkout code
+        if: steps.cadence.outputs.run_report == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        if: steps.cadence.outputs.run_report == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ">=24.5.0"
+
+      - name: Generate dry-run branch cleanup report
+        if: steps.cadence.outputs.run_report == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_OWNER: ${{ github.event_name == 'schedule' && 'grafana' || inputs.owner }}
+          INPUT_REPO: ${{ github.event_name == 'schedule' && 'faro-react-native-sdk' || inputs.repo }}
+          INPUT_MIN_MERGED_AGE_DAYS: ${{ github.event_name == 'schedule' && '14' || inputs.min_merged_age_days }}
+          INPUT_INCLUDE_AUTOMATION: ${{ github.event_name == 'schedule' && 'false' || inputs.include_automation }}
+        run: |
+          node scripts/audit-stale-branches.mjs \
+            --owner "$INPUT_OWNER" \
+            --repo "$INPUT_REPO" \
+            --min-merged-age-days "$INPUT_MIN_MERGED_AGE_DAYS" \
+            --include-automation "$INPUT_INCLUDE_AUTOMATION" \
+            > branch-cleanup-dry-run.md
+
+      - name: Print report summary
+        if: steps.cadence.outputs.run_report == 'true'
+        run: sed -n '1,80p' branch-cleanup-dry-run.md
+
+      - name: Publish report to job summary
+        if: steps.cadence.outputs.run_report == 'true'
+        run: cat branch-cleanup-dry-run.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create GitHub issue report
+        if: steps.cadence.outputs.run_report == 'true' && (github.event_name == 'schedule' || inputs.create_issue)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          report_date="$(date -u +%F)"
+          issue_title="Branch cleanup dry-run report - $report_date"
+
+          {
+            echo "Automated read-only branch cleanup report."
+            echo
+            echo "Workflow run: $RUN_URL"
+            echo
+            cat branch-cleanup-dry-run.md
+          } > branch-cleanup-issue.md
+
+          gh issue create \
+            --repo "$ISSUE_REPO" \
+            --title "$issue_title" \
+            --body-file branch-cleanup-issue.md
+
+      - name: Upload report
+        if: steps.cadence.outputs.run_report == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: branch-cleanup-dry-run
+          path: branch-cleanup-dry-run.md
+          retention-days: 14

--- a/.github/workflows/branch-cleanup-dry-run.yaml
+++ b/.github/workflows/branch-cleanup-dry-run.yaml
@@ -32,13 +32,17 @@ on:
 
 permissions:
   contents: read
-  issues: write
   pull-requests: read
 
 jobs:
   audit:
     name: Audit stale branches
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      create_issue: ${{ steps.issue.outputs.create_issue }}
     steps:
       - name: Check 14-day report cadence
         id: cadence
@@ -99,15 +103,74 @@ jobs:
         if: steps.cadence.outputs.run_report == 'true'
         run: cat branch-cleanup-dry-run.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Check whether an issue is needed
+        id: issue
+        if: steps.cadence.outputs.run_report == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CREATE_ISSUE_INPUT: ${{ inputs.create_issue }}
+        run: |
+          merged_candidates="$(awk -F': ' '/^- Merged branch cleanup candidates:/ {print $2}' branch-cleanup-dry-run.md)"
+          closed_unmerged="$(awk -F': ' '/^- Closed-unmerged branches needing review:/ {print $2}' branch-cleanup-dry-run.md)"
+          no_pr="$(awk -F': ' '/^- No-PR branches needing review:/ {print $2}' branch-cleanup-dry-run.md)"
+          automation="$(awk -F': ' '/^- Automation branches skipped:/ {print $2}' branch-cleanup-dry-run.md)"
+
+          merged_candidates="${merged_candidates:-0}"
+          closed_unmerged="${closed_unmerged:-0}"
+          no_pr="${no_pr:-0}"
+          automation="${automation:-0}"
+          actionable_count="$((merged_candidates + closed_unmerged + no_pr + automation))"
+
+          echo "actionable_count=$actionable_count" >> "$GITHUB_OUTPUT"
+
+          if [ "$CREATE_ISSUE_INPUT" = "true" ]; then
+            echo "create_issue=true" >> "$GITHUB_OUTPUT"
+            echo "Creating an issue because create_issue=true was requested manually." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$EVENT_NAME" = "schedule" ] && [ "$actionable_count" -gt 0 ]; then
+            echo "create_issue=true" >> "$GITHUB_OUTPUT"
+            echo "Creating an issue because $actionable_count actionable branch cleanup items were found." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "create_issue=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping issue creation because there are no actionable branch cleanup items." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload report
+        if: steps.cadence.outputs.run_report == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: branch-cleanup-dry-run
+          path: branch-cleanup-dry-run.md
+          retention-days: 14
+
+  create-issue:
+    name: Create issue report
+    needs: audit
+    if: needs.audit.outputs.create_issue == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Download report
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: branch-cleanup-dry-run
+
       - name: Create GitHub issue report
-        if: steps.cadence.outputs.run_report == 'true' && (github.event_name == 'schedule' || inputs.create_issue)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_REPO: ${{ github.repository }}
+          ISSUE_LABEL: branch-cleanup
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           report_date="$(date -u +%F)"
           issue_title="Branch cleanup dry-run report - $report_date"
+
+          if ! gh label list --repo "$ISSUE_REPO" --search "$ISSUE_LABEL" --json name --jq '.[].name' | grep -Fxq "$ISSUE_LABEL"; then
+            gh label create "$ISSUE_LABEL" \
+              --repo "$ISSUE_REPO" \
+              --color "0e8a16" \
+              --description "Branch cleanup automation reports"
+          fi
 
           {
             echo "Automated read-only branch cleanup report."
@@ -120,12 +183,5 @@ jobs:
           gh issue create \
             --repo "$ISSUE_REPO" \
             --title "$issue_title" \
+            --label "$ISSUE_LABEL" \
             --body-file branch-cleanup-issue.md
-
-      - name: Upload report
-        if: steps.cadence.outputs.run_report == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: branch-cleanup-dry-run
-          path: branch-cleanup-dry-run.md
-          retention-days: 14

--- a/.github/workflows/branch-cleanup-dry-run.yaml
+++ b/.github/workflows/branch-cleanup-dry-run.yaml
@@ -14,7 +14,7 @@ on:
       min_merged_age_days:
         description: Minimum age in days before merged branches are cleanup candidates
         required: true
-        default: "14"
+        default: '14'
       include_automation:
         description: Include renovate/dependabot/release-please branches as candidates
         required: true
@@ -28,7 +28,7 @@ on:
   schedule:
     # GitHub cron does not support "every 14 days" directly. This runs weekly,
     # then the cadence step below only lets the report continue every other week.
-    - cron: "0 14 * * 4"
+    - cron: '0 14 * * 4'
 
 permissions:
   contents: read
@@ -44,7 +44,7 @@ jobs:
         id: cadence
         env:
           EVENT_NAME: ${{ github.event_name }}
-          REPORT_ANCHOR_DATE: "2026-05-28"
+          REPORT_ANCHOR_DATE: '2026-05-28'
         run: |
           if [ "$EVENT_NAME" != "schedule" ]; then
             echo "run_report=true" >> "$GITHUB_OUTPUT"
@@ -73,7 +73,7 @@ jobs:
         if: steps.cadence.outputs.run_report == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ">=24.5.0"
+          node-version: '>=24.5.0'
 
       - name: Generate dry-run branch cleanup report
         if: steps.cadence.outputs.run_report == 'true'

--- a/scripts/audit-stale-branches.mjs
+++ b/scripts/audit-stale-branches.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+const token = process.env.GITHUB_TOKEN;
+
+if (!token) {
+  console.error('GITHUB_TOKEN is required.');
+  process.exit(1);
+}
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 2) {
+  args.set(process.argv[index], process.argv[index + 1]);
+}
+
+const owner = args.get('--owner') ?? process.env.GITHUB_REPOSITORY_OWNER ?? 'grafana';
+const repo =
+  args.get('--repo') ??
+  process.env.GITHUB_REPOSITORY?.split('/')[1] ??
+  'faro-react-native-sdk';
+const minMergedAgeDays = Number(args.get('--min-merged-age-days') ?? '7');
+const includeAutomation = args.get('--include-automation') === 'true';
+
+if (!Number.isFinite(minMergedAgeDays) || minMergedAgeDays < 0) {
+  console.error('--min-merged-age-days must be a non-negative number.');
+  process.exit(1);
+}
+
+const graphqlUrl = 'https://api.github.com/graphql';
+const headers = {
+  authorization: `Bearer ${token}`,
+  'content-type': 'application/json',
+  'user-agent': 'mobile-o11y-branch-audit',
+};
+
+async function graphql(query, variables) {
+  const response = await fetch(graphqlUrl, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub GraphQL request failed: ${response.status} ${await response.text()}`);
+  }
+
+  const payload = await response.json();
+  if (payload.errors?.length) {
+    throw new Error(`GitHub GraphQL errors: ${JSON.stringify(payload.errors)}`);
+  }
+
+  return payload.data;
+}
+
+async function getBranches() {
+  const branches = [];
+  let cursor = null;
+  let defaultBranchName = 'main';
+
+  do {
+    const data = await graphql(
+      `query($owner: String!, $repo: String!, $cursor: String) {
+        repository(owner: $owner, name: $repo) {
+          defaultBranchRef { name }
+          refs(
+            refPrefix: "refs/heads/"
+            first: 100
+            after: $cursor
+            orderBy: { field: TAG_COMMIT_DATE, direction: DESC }
+          ) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              name
+              target {
+                ... on Commit {
+                  oid
+                  committedDate
+                  messageHeadline
+                  author { user { login } name }
+                }
+              }
+              associatedPullRequests(first: 10) {
+                nodes {
+                  number
+                  title
+                  state
+                  merged
+                  mergedAt
+                  isDraft
+                  url
+                  author { login }
+                  headRefName
+                  headRepository { name owner { login } }
+                  baseRepository { name owner { login } }
+                }
+              }
+            }
+          }
+        }
+      }`,
+      { owner, repo, cursor }
+    );
+
+    defaultBranchName = data.repository.defaultBranchRef?.name ?? defaultBranchName;
+    branches.push(...data.repository.refs.nodes);
+    cursor = data.repository.refs.pageInfo.hasNextPage
+      ? data.repository.refs.pageInfo.endCursor
+      : null;
+  } while (cursor);
+
+  return { branches, defaultBranchName };
+}
+
+function isAutomationBranch(branchName) {
+  return (
+    branchName.startsWith('dependabot/') ||
+    branchName.startsWith('renovate/') ||
+    branchName.startsWith('release-please--')
+  );
+}
+
+function mergedAgeDays(mergedAt) {
+  return (Date.now() - new Date(mergedAt).getTime()) / 86_400_000;
+}
+
+function classify(branch, defaultBranchName) {
+  const pullRequests = branch.associatedPullRequests.nodes.filter(
+    (candidate) =>
+      candidate.headRefName === branch.name &&
+      candidate.headRepository?.name === repo &&
+      candidate.headRepository?.owner?.login === owner &&
+      candidate.baseRepository?.name === repo &&
+      candidate.baseRepository?.owner?.login === owner
+  );
+  const pullRequest =
+    pullRequests.find((candidate) => candidate.merged) ??
+    pullRequests.find((candidate) => candidate.state === 'OPEN') ??
+    pullRequests[0];
+
+  if (branch.name === defaultBranchName) {
+    return { bucket: 'protected', branch, pullRequest, reason: 'default branch' };
+  }
+
+  const automation = isAutomationBranch(branch.name);
+  if (automation && !includeAutomation) {
+    return { bucket: 'automation', branch, pullRequest, reason: 'automation branch' };
+  }
+
+  if (!pullRequest) {
+    return { bucket: 'noPr', branch, pullRequest, reason: 'no linked PR found' };
+  }
+
+  if (pullRequest.state === 'OPEN') {
+    return { bucket: 'open', branch, pullRequest, reason: 'open PR' };
+  }
+
+  if (!pullRequest.merged) {
+    return { bucket: 'closedUnmerged', branch, pullRequest, reason: 'closed but not merged' };
+  }
+
+  if (mergedAgeDays(pullRequest.mergedAt) < minMergedAgeDays) {
+    return {
+      bucket: 'recentMerged',
+      branch,
+      pullRequest,
+      reason: `merged less than ${minMergedAgeDays} days ago`,
+    };
+  }
+
+  return { bucket: 'mergedCandidate', branch, pullRequest, reason: 'merged PR branch' };
+}
+
+function row(item) {
+  const pr = item.pullRequest;
+  const prText = pr ? `[#${pr.number}](${pr.url})` : '-';
+  const updated = item.branch.target?.committedDate ?? '-';
+  const author =
+    item.branch.target?.author?.user?.login ?? item.branch.target?.author?.name ?? '-';
+  const sha = item.branch.target?.oid ?? '-';
+  return `| \`${item.branch.name}\` | ${prText} | ${author} | ${updated} | \`${sha}\` | ${item.reason} |`;
+}
+
+function section(title, items) {
+  if (!items.length) {
+    return `## ${title}\n\nNone.\n`;
+  }
+
+  return [
+    `## ${title}`,
+    '',
+    '| Branch | PR | Last author | Last commit date | SHA | Reason |',
+    '| --- | --- | --- | --- | --- | --- |',
+    ...items.map(row),
+    '',
+  ].join('\n');
+}
+
+const { branches, defaultBranchName } = await getBranches();
+const groups = branches.reduce((accumulator, branch) => {
+  const item = classify(branch, defaultBranchName);
+  accumulator[item.bucket] ??= [];
+  accumulator[item.bucket].push(item);
+  return accumulator;
+}, {});
+
+const report = [
+  `# Branch Cleanup Dry Run: ${owner}/${repo}`,
+  '',
+  `Generated: ${new Date().toISOString()}`,
+  '',
+  `This is a dry-run report. It does not delete branches.`,
+  `Cross-repo audits require a token with read access to the target repository.`,
+  '',
+  `Minimum merged-branch age: ${minMergedAgeDays} days`,
+  `Automation branches included as delete candidates: ${includeAutomation}`,
+  '',
+  '## Summary',
+  '',
+  `- Total branches: ${branches.length}`,
+  `- Merged branch cleanup candidates: ${groups.mergedCandidate?.length ?? 0}`,
+  `- Recent merged branches skipped: ${groups.recentMerged?.length ?? 0}`,
+  `- Open PR branches skipped: ${groups.open?.length ?? 0}`,
+  `- Closed-unmerged branches needing review: ${groups.closedUnmerged?.length ?? 0}`,
+  `- No-PR branches needing review: ${groups.noPr?.length ?? 0}`,
+  `- Automation branches skipped: ${groups.automation?.length ?? 0}`,
+  '',
+  section('Merged Branch Cleanup Candidates', groups.mergedCandidate ?? []),
+  section('Recent Merged Branches Skipped', groups.recentMerged ?? []),
+  section('Open PR Branches Skipped', groups.open ?? []),
+  section('Closed-Unmerged Branches Needing Review', groups.closedUnmerged ?? []),
+  section('No-PR Branches Needing Review', groups.noPr ?? []),
+  section('Automation Branches Skipped', groups.automation ?? []),
+].join('\n');
+
+console.log(report);


### PR DESCRIPTION
## Summary

Adds the same scheduled branch cleanup report we started in `mobile-o11y-demo`, adjusted for `faro-react-native-sdk`.

Reference: https://github.com/grafana/mobile-o11y-demo/pull/67

This is still read-only. It does not delete branches. The goal is to make leftover branch cleanup easier to review without manually clicking through the branch list.

## What changed

- Adds a branch cleanup dry-run workflow
- Runs on a 14-day cadence
- Keeps manual runs available through `workflow_dispatch`
- Creates a GitHub issue with the report on scheduled runs
- Adds an optional manual `create_issue` input for one-off reports/testing
- Uploads the report as an artifact and writes it to the Action summary

## Notes

The first local report found no merged-PR cleanup candidates, but it did surface no-PR and automation branches. That seems useful for this repo because those are categories GitHub's auto-delete setting does not cover.

I kept this as a draft so we can decide if we want this reporting pattern in the React Native SDK repo too, or keep it only in `mobile-o11y-demo` for now.

## Testing

I checked this locally by running the audit script against `grafana/faro-react-native-sdk` with the 14-day settings and confirmed it generated the expected dry-run report. I also ran a basic syntax check on the script and checked the diff for formatting issues.
