### PR TITLE
fix(react-native): do not fail iOS Release build on source map upload errors

### DIFF
--- a/packages/react-native/ios/faro-upload-composed-source-map.sh
+++ b/packages/react-native/ios/faro-upload-composed-source-map.sh
@@ -77,14 +77,17 @@ fi
 
 NODE_BIN="${NODE_BINARY:-node}"
 
-if ! "$NODE_BIN" "$CLI_PATH" \
+upload_exit=0
+"$NODE_BIN" "$CLI_PATH" \
   --verbose \
   --map "$MAP" \
   --endpoint "$FARO_SOURCEMAP_ENDPOINT" \
   --app-id "$FARO_SOURCEMAP_APP_ID" \
   --stack-id "$FARO_SOURCEMAP_STACK_ID" \
   --api-key "$FARO_SOURCEMAP_API_KEY" \
-  --bundle-id "$FARO_BUNDLE_ID"; then
-  echo "warning: [Faro] Composed source map upload failed (exit $?)"
+  --bundle-id "$FARO_BUNDLE_ID" || upload_exit=$?
+
+if [ "$upload_exit" -ne 0 ]; then
+  echo "warning: [Faro] Composed source map upload failed (exit $upload_exit)"
 fi
 exit 0

--- a/packages/react-native/ios/faro-upload-composed-source-map.sh
+++ b/packages/react-native/ios/faro-upload-composed-source-map.sh
@@ -77,11 +77,14 @@ fi
 
 NODE_BIN="${NODE_BINARY:-node}"
 
-exec "$NODE_BIN" "$CLI_PATH" \
+if ! "$NODE_BIN" "$CLI_PATH" \
   --verbose \
   --map "$MAP" \
   --endpoint "$FARO_SOURCEMAP_ENDPOINT" \
   --app-id "$FARO_SOURCEMAP_APP_ID" \
   --stack-id "$FARO_SOURCEMAP_STACK_ID" \
   --api-key "$FARO_SOURCEMAP_API_KEY" \
-  --bundle-id "$FARO_BUNDLE_ID"
+  --bundle-id "$FARO_BUNDLE_ID"; then
+  echo "warning: [Faro] Composed source map upload failed (exit $?)"
+fi
+exit 0


### PR DESCRIPTION
## Summary

The autolinked iOS Run Script phase (`[Faro] Upload composed source map (Release)`) previously ended with `exec` on the upload CLI. If `faro-cli metro upload` failed (network, auth, missing credentials, transient endpoint issues), Xcode treated it as a build failure.

This change aligns the upload step with the script’s documented behavior: **never fail the Release build**. Upload errors are logged as warnings and the phase exits 0, matching how skip conditions (missing env, missing map, non-Release config) already behave.

Client apps do not need to own or patch the Xcode phase — `pod install` will re-inline this script from the package on the next dependency bump.

## Context

Raised during review of [grafana/mobile-o11y-demo#51](https://github.com/grafana/mobile-o11y-demo/pull/51): editing `project.pbxproj` in a consumer app is not durable because React Native autolinking re-inlines the script from `@grafana/faro-react-native` on every `pod install`.

## What changed

- `packages/react-native/ios/faro-upload-composed-source-map.sh`: replace `exec "$NODE_BIN" "$CLI_PATH" …` with a guarded invocation that logs `warning: [Faro] Composed source map upload failed (exit $?)` on non-zero exit, then `exit 0`.
- Skip paths (Debug, `FARO_SKIP_SOURCEMAP_UPLOAD`, missing shim/map/env) are unchanged.

## Follow-up

After this releases on npm, consumer apps (e.g. `mobile-o11y-demo`) should bump `@grafana/faro-react-native` and run `cd ios && pod install` to pick up the updated autolinked script.