### PR TITLE
chore(deps): lower npm release-age gate to 3 days

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -11,6 +11,6 @@ enableScripts: false
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 7d
+npmMinimalAgeGate: 3d
 
 yarnPath: .yarn/releases/yarn-4.14.1.cjs


### PR DESCRIPTION
Lowers yarn's `npmMinimalAgeGate` from 7d to 3d to align with the 3-day Grafana org Renovate default.

_PR description authored by Claude on Domas's behalf._